### PR TITLE
Move settings to top-left with dark mode toggle

### DIFF
--- a/components/NavBar.js
+++ b/components/NavBar.js
@@ -23,61 +23,20 @@ export default function NavBar() {
   }, [darkMode]);
 
   return (
-    <nav style={{
-      position: 'fixed',
-      bottom: '20px',
-      left: '50%',
-      transform: 'translateX(-50%)',
-      background: darkMode ? '#222' : '#fff',
-      borderRadius: '12px',
-      boxShadow: '0 4px 6px rgba(0,0,0,0.1)',
-      padding: '8px 16px',
-      display: 'flex',
-      gap: '16px',
-      zIndex: 1000
-    }}>
-      {navItems.map((item) => (
-        <Link key={item.href} href={item.href} style={{ textDecoration: 'none', color: darkMode ? '#fff' : '#333' }}>
-          <div
-            style={{
-              display: 'flex',
-              flexDirection: 'column',
-              alignItems: 'center',
-              padding: '8px',
-              borderRadius: '8px',
-              transition: 'background 0.2s'
-            }}
-            onMouseEnter={(e) => e.currentTarget.style.background = darkMode ? '#444' : '#f0f0f0'}
-            onMouseLeave={(e) => e.currentTarget.style.background = 'transparent'}
-          >
-            <span style={{ fontSize: '20px' }}>{item.icon}</span>
-          </div>
-        </Link>
-      ))}
-
-      <button
-        onClick={() => setDarkMode(!darkMode)}
-        style={{
-          background: 'none',
-          border: 'none',
-          cursor: 'pointer',
-          padding: '8px',
-          borderRadius: '8px',
-          color: darkMode ? '#fff' : '#333'
-        }}
-      >
-        <span style={{ fontSize: '20px' }}>{darkMode ? '☀️' : '🌙'}</span>
-      </button>
-
+    <>
       <button
         onClick={() => setShowSettings(!showSettings)}
         style={{
+          position: 'fixed',
+          top: '20px',
+          left: '20px',
           background: 'none',
           border: 'none',
           cursor: 'pointer',
           padding: '8px',
           borderRadius: '8px',
-          color: darkMode ? '#fff' : '#333'
+          color: darkMode ? '#fff' : '#333',
+          zIndex: 1002
         }}
       >
         <span style={{ fontSize: '20px' }}>⚙️</span>
@@ -87,36 +46,90 @@ export default function NavBar() {
         <div
           style={{
             position: 'fixed',
-            bottom: '80px',
-            left: '50%',
-            transform: 'translateX(-50%)',
+            top: '60px',
+            left: '20px',
             background: darkMode ? '#222' : '#fff',
             border: '1px solid',
             borderColor: darkMode ? '#555' : '#ccc',
             padding: '12px',
             borderRadius: '8px',
-            display: 'grid',
-            gridTemplateColumns: 'repeat(2, 1fr)',
+            display: 'flex',
+            flexDirection: 'column',
             gap: '8px',
             zIndex: 1001
           }}
         >
-          {['Profile', 'Notifications', 'Privacy', 'Help'].map((label) => (
-            <div
-              key={label}
-              style={{
-                padding: '8px',
-                borderRadius: '4px',
-                background: darkMode ? '#444' : '#f0f0f0',
-                textAlign: 'center',
-                color: darkMode ? '#fff' : '#333'
-              }}
-            >
-              {label}
-            </div>
-          ))}
+          <button
+            onClick={() => setDarkMode(!darkMode)}
+            style={{
+              background: darkMode ? '#444' : '#f0f0f0',
+              border: 'none',
+              borderRadius: '4px',
+              padding: '8px',
+              cursor: 'pointer',
+              color: darkMode ? '#fff' : '#333'
+            }}
+          >
+            {darkMode ? '☀️ Light Mode' : '🌙 Dark Mode'}
+          </button>
+
+          <div
+            style={{
+              display: 'grid',
+              gridTemplateColumns: 'repeat(2, 1fr)',
+              gap: '8px'
+            }}
+          >
+            {['Profile', 'Notifications', 'Privacy', 'Help'].map((label) => (
+              <div
+                key={label}
+                style={{
+                  padding: '8px',
+                  borderRadius: '4px',
+                  background: darkMode ? '#444' : '#f0f0f0',
+                  textAlign: 'center',
+                  color: darkMode ? '#fff' : '#333'
+                }}
+              >
+                {label}
+              </div>
+            ))}
+          </div>
         </div>
       )}
-    </nav>
+
+      <nav style={{
+        position: 'fixed',
+        bottom: '20px',
+        left: '50%',
+        transform: 'translateX(-50%)',
+        background: darkMode ? '#222' : '#fff',
+        borderRadius: '12px',
+        boxShadow: '0 4px 6px rgba(0,0,0,0.1)',
+        padding: '8px 16px',
+        display: 'flex',
+        gap: '16px',
+        zIndex: 1000
+      }}>
+        {navItems.map((item) => (
+          <Link key={item.href} href={item.href} style={{ textDecoration: 'none', color: darkMode ? '#fff' : '#333' }}>
+            <div
+              style={{
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                padding: '8px',
+                borderRadius: '8px',
+                transition: 'background 0.2s'
+              }}
+              onMouseEnter={(e) => e.currentTarget.style.background = darkMode ? '#444' : '#f0f0f0'}
+              onMouseLeave={(e) => e.currentTarget.style.background = 'transparent'}
+            >
+              <span style={{ fontSize: '20px' }}>{item.icon}</span>
+            </div>
+          </Link>
+        ))}
+      </nav>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- Move settings gear to top-left corner of the screen
- Add dark/light mode toggle inside settings panel and remove toggle from bottom nav

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9a56238dc8332a307aae3822c8471