### PR TITLE
Add profile page and top-left profile icon

### DIFF
--- a/components/NavBar.js
+++ b/components/NavBar.js
@@ -47,6 +47,27 @@ export default function NavBar() {
 
   return (
     <>
+      <Link
+        href="/profile"
+        style={{
+          position: 'fixed',
+          top: '20px',
+          left: '20px',
+          width: '40px',
+          height: '40px',
+          borderRadius: '50%',
+          overflow: 'hidden',
+          background: darkMode ? '#444' : '#f0f0f0',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          textDecoration: 'none',
+          zIndex: 1002
+        }}
+      >
+        <span style={{ fontSize: '20px', color: darkMode ? '#fff' : '#333' }}>👤</span>
+      </Link>
+
       <button
         ref={buttonRef}
         onClick={() => setShowSettings(!showSettings)}

--- a/pages/profile.js
+++ b/pages/profile.js
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function Profile() {
+  return (
+    <div style={{ padding: '20px' }}>
+      <h1>Profile Page</h1>
+      <p>This is your profile.</p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a simple profile page
- show rounded profile icon linking to profile page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9ab22629c8332b5bf67da3e30740f