### PR TITLE
Fix product list overlap and uniform background

### DIFF
--- a/components/NavBar.js
+++ b/components/NavBar.js
@@ -16,10 +16,10 @@ export default function NavBar() {
 
   useEffect(() => {
     if (darkMode) {
-      document.body.style.background = 'linear-gradient(135deg, #1f1f1f 0%, #3d3d3d 100%)';
+      document.body.style.background = '#1f1f1f';
       document.body.style.color = '#fff';
     } else {
-      document.body.style.background = 'linear-gradient(135deg, #c3ecff 0%, #eafaf1 100%)';
+      document.body.style.background = '#eafaf1';
       document.body.style.color = '#000';
     }
   }, [darkMode]);

--- a/pages/index.js
+++ b/pages/index.js
@@ -11,7 +11,13 @@ export default function Home() {
   ];
 
   return (
-    <div style={{ padding: '20px' }}>
+    <div
+      style={{
+        padding: '20px',
+        paddingTop: '80px',
+        paddingLeft: '80px'
+      }}
+    >
       <h1>Product List</h1>
       <div style={{ display: 'flex', gap: '20px', flexWrap: 'wrap' }}>
         {products.map((product) => (

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,7 +1,7 @@
 body {
   margin: 0;
   font-family: Arial, sans-serif;
-  background: linear-gradient(135deg, #c3ecff 0%, #eafaf1 100%);
+  background: #eafaf1;
 }
 
 .glass-card {


### PR DESCRIPTION
## Summary
- prevent product list from overlapping profile link with additional top and left padding
- replace gradient background with solid colors and adjust NavBar dark mode toggle

## Testing
- `npm test`
- `npm run lint` *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68ba2fc656808332adbf196d2bd817e6