### PR TITLE
feat: support GROQ key from public env

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,9 @@ npm run dev
 ```
 
 The home page displays "Hello World" and includes a button to toggle between light and dark modes.
+
+### Chatbot
+
+To enable the chatbot, provide your Groq API key via an environment variable
+named `GROQ_API_KEY` (or `NEXT_PUBLIC_GROQ_API_KEY`). The API route reads this
+value to authenticate requests to Groq.

--- a/pages/api/chat.js
+++ b/pages/api/chat.js
@@ -4,7 +4,12 @@ export default async function handler(req, res) {
   }
 
   const { message } = req.body;
-  const apiKey = process.env.GROQ_API_KEY;
+
+  // Allow using either GROQ_API_KEY or NEXT_PUBLIC_GROQ_API_KEY so the
+  // route works whether the key is defined for server-side use only or
+  // exposed to the client during development.
+  const apiKey =
+    process.env.GROQ_API_KEY || process.env.NEXT_PUBLIC_GROQ_API_KEY;
 
   if (!apiKey) {
     console.error('GROQ_API_KEY is not set');
@@ -25,7 +30,10 @@ export default async function handler(req, res) {
     });
 
     if (!response.ok) {
-      throw new Error(`Groq API responded with ${response.status}`);
+      const errorText = await response.text();
+      throw new Error(
+        `Groq API responded with ${response.status}: ${errorText}`
+      );
     }
 
     const completion = await response.json();


### PR DESCRIPTION
## Summary
- allow API route to use GROQ_API_KEY or NEXT_PUBLIC_GROQ_API_KEY
- document Groq key requirement for chatbot

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba3d0570a083329b0d71846003de43