### PR TITLE
fix: remove preventDefault from touchstart

### DIFF
--- a/components/Chatbot.js
+++ b/components/Chatbot.js
@@ -54,7 +54,6 @@ export default function Chatbot() {
     startDrag(touch.clientX, touch.clientY);
     window.addEventListener('touchmove', onTouchMove);
     window.addEventListener('touchend', onTouchEnd);
-    e.preventDefault();
   };
 
   const onTouchMove = (e) => {


### PR DESCRIPTION
## Summary
- remove preventDefault from touchstart handler to avoid passive listener error

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ba43d748148332a5b1dd952424b0de