### PR TITLE
Use openai/gpt-oss-20b model in chat API

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,4 @@ The home page displays "Hello World" and includes a button to toggle between lig
 To enable the chatbot, provide your Groq API key via an environment variable
 named `GROQ_API_KEY` (or `NEXT_PUBLIC_GROQ_API_KEY`). The API route reads this
 value to authenticate requests to Groq.
+By default, it uses the `openai/gpt-oss-20b` model for chat completions.

--- a/pages/api/chat.js
+++ b/pages/api/chat.js
@@ -24,7 +24,7 @@ export default async function handler(req, res) {
         Authorization: `Bearer ${apiKey}`,
       },
       body: JSON.stringify({
-        model: 'mixtral-8x7b-32768',
+        model: 'openai/gpt-oss-20b',
         messages: [{ role: 'user', content: message }],
       }),
     });


### PR DESCRIPTION
## Summary
- Switch chat completion model to `openai/gpt-oss-20b`
- Document default model in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba4a0da5e48332b2b3af0611c93d23