### PR TITLE
feat: integrate OpenAI client for chat API

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The home page displays "Hello World" and includes a button to toggle between lig
 ### Chatbot
 
 To enable the chatbot, provide your Groq API key via an environment variable
-named `GROQ_API_KEY` (or `NEXT_PUBLIC_GROQ_API_KEY`). The API route reads this
-value to authenticate requests to Groq.
-By default, it uses the `openai/gpt-oss-20b` model for chat completions.
+named `GROQ_API_KEY` (or `NEXT_PUBLIC_GROQ_API_KEY`). The API route, implemented
+with the official OpenAI SDK and configured to Groq's API, reads this value to
+authenticate requests. By default, it uses the `openai/gpt-oss-20b` model for
+chat completions.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   },
   "dependencies": {
     "next": "^14.0.0",
+    "openai": "^4.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
-    }
   }
+}

--- a/pages/api/chat.js
+++ b/pages/api/chat.js
@@ -1,3 +1,5 @@
+import OpenAI from 'openai';
+
 export default async function handler(req, res) {
   if (req.method !== 'POST') {
     return res.status(405).json({ error: 'Method not allowed' });
@@ -16,27 +18,17 @@ export default async function handler(req, res) {
     return res.status(500).json({ error: 'Server misconfiguration' });
   }
 
+  const client = new OpenAI({
+    apiKey,
+    baseURL: 'https://api.groq.com/openai/v1',
+  });
+
   try {
-    const response = await fetch('https://api.groq.com/openai/v1/chat/completions', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${apiKey}`,
-      },
-      body: JSON.stringify({
-        model: 'openai/gpt-oss-20b',
-        messages: [{ role: 'user', content: message }],
-      }),
+    const completion = await client.chat.completions.create({
+      model: 'openai/gpt-oss-20b',
+      messages: [{ role: 'user', content: message }],
     });
 
-    if (!response.ok) {
-      const errorText = await response.text();
-      throw new Error(
-        `Groq API responded with ${response.status}: ${errorText}`
-      );
-    }
-
-    const completion = await response.json();
     const reply = completion.choices?.[0]?.message?.content || '';
     res.status(200).json({ reply });
   } catch (error) {


### PR DESCRIPTION
## Summary
- configure OpenAI SDK to call Groq's `openai/gpt-oss-20b` model
- document required `GROQ_API_KEY` environment variable
- describe OpenAI SDK usage in README

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/openai)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba4bccd7608332ad256bf04c5ae588