### PR TITLE
Add explore API and connect explore page to AI chat

### DIFF
--- a/pages/api/explore.js
+++ b/pages/api/explore.js
@@ -1,0 +1,43 @@
+import OpenAI from 'openai';
+
+const apiKey =
+  process.env.GROQ_API_KEY || process.env.NEXT_PUBLIC_GROQ_API_KEY;
+
+const client = new OpenAI({
+  apiKey,
+  baseURL: 'https://api.groq.com/openai/v1',
+});
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const { message } = req.body;
+
+  if (!apiKey) {
+    console.error('GROQ_API_KEY is not set');
+    return res.status(500).json({ error: 'Server misconfiguration' });
+  }
+
+  try {
+    const completion = await client.chat.completions.create({
+      model: 'openai/gpt-oss-20b',
+      messages: [
+        {
+          role: 'system',
+          content:
+            'You are an exploratory ai assistant. Max token 500. You are built by Flowdira ltd. And Your owner is Nitesh.',
+        },
+        { role: 'user', content: message },
+      ],
+      max_tokens: 500,
+    });
+
+    const reply = completion.choices?.[0]?.message?.content || '';
+    res.status(200).json({ reply });
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ error: 'Failed to fetch completion' });
+  }
+}

--- a/pages/explore.js
+++ b/pages/explore.js
@@ -4,10 +4,24 @@ export default function Explore() {
   const [messages, setMessages] = useState([]);
   const [input, setInput] = useState('');
 
-  const handleExplore = () => {
-    if (!input.trim()) return;
-    setMessages((prev) => [...prev, input]);
+  const handleExplore = async () => {
+    const text = input.trim();
+    if (!text) return;
+    setMessages((prev) => [...prev, { sender: 'user', text }]);
     setInput('');
+    try {
+      const response = await fetch('/api/explore', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ message: text }),
+      });
+      const data = await response.json();
+      if (data.reply) {
+        setMessages((prev) => [...prev, { sender: 'ai', text: data.reply }]);
+      }
+    } catch (error) {
+      console.error(error);
+    }
   };
 
   return (
@@ -17,7 +31,7 @@ export default function Explore() {
         padding: '80px 20px 20px',
         display: 'flex',
         flexDirection: 'column',
-        alignItems: 'center'
+        alignItems: 'center',
       }}
     >
       <h1>Explore Page</h1>
@@ -30,12 +44,12 @@ export default function Explore() {
             height: '300px',
             overflowY: 'auto',
             marginBottom: '12px',
-            background: 'rgba(255,255,255,0.5)'
+            background: 'rgba(255,255,255,0.5)',
           }}
         >
           {messages.map((msg, idx) => (
             <div key={idx} style={{ marginBottom: '8px' }}>
-              {msg}
+              <strong>{msg.sender === 'user' ? 'You' : 'AI'}:</strong> {msg.text}
             </div>
           ))}
         </div>
@@ -49,7 +63,7 @@ export default function Explore() {
               flex: 1,
               padding: '8px',
               borderRadius: '4px',
-              border: '1px solid #ccc'
+              border: '1px solid #ccc',
             }}
           />
           <button
@@ -60,7 +74,7 @@ export default function Explore() {
               border: 'none',
               padding: '8px 16px',
               borderRadius: '4px',
-              cursor: 'pointer'
+              cursor: 'pointer',
             }}
           >
             Explore


### PR DESCRIPTION
## Summary
- connect the explore page's chatbox to an API and render AI responses
- add a dedicated `/api/explore` endpoint powered by Groq's OpenAI-compatible API

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ba8fb3316c83328fab8014a0186abe